### PR TITLE
Improve weather/air error handling, messaging, and endpoint security

### DIFF
--- a/plugins/weather.py
+++ b/plugins/weather.py
@@ -30,8 +30,9 @@ from . import LOGS, async_searcher, get_string, udB, ultroid_cmd
 
 async def get_timezone(offset_seconds, use_utc=False):
     offset = timedelta(seconds=offset_seconds)
-    hours, remainder = divmod(offset.seconds, 3600)
-    sign = "+" if offset.total_seconds() >= 0 else "-"
+    total_seconds = int(offset.total_seconds())
+    hours = abs(total_seconds) // 3600
+    sign = "+" if total_seconds >= 0 else "-"
     timezone = "UTC" if use_utc else "GMT"
     if use_utc:
         for m in pytz.all_timezones:

--- a/plugins/weather.py
+++ b/plugins/weather.py
@@ -18,6 +18,7 @@
 
 import datetime
 import time
+import asyncio
 from datetime import timedelta
 from json import JSONDecodeError
 
@@ -65,7 +66,7 @@ async def get_air_pollution_data(latitude, longitude, api_key):
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.get(url) as response:
                 data = await response.json()
-    except TimeoutError:
+    except (asyncio.TimeoutError, TimeoutError):
         LOGS.exception("OpenWeather air pollution request timed out.")
         return None, "Air quality lookup timed out. Please try again in a moment."
     except aiohttp.ClientError:
@@ -90,7 +91,7 @@ async def get_geocode_data(input_str: str):
         geo_url = f"https://geocode.xyz/{input_str}?json=1"
     try:
         geo_data = await async_searcher(geo_url, re_json=True, timeout=12)
-    except TimeoutError:
+    except (asyncio.TimeoutError, TimeoutError):
         LOGS.exception("Geocoding request timed out for location: %s", input_str)
         return None, "Geocoding timed out. Try city,country format."
     except aiohttp.ClientError:
@@ -129,10 +130,11 @@ async def weather(event):
         return
     elif input_str == "butler":
         await event.eor("Search butler,au for Australia.", time=5)
+        return
     sample_url = f"https://api.openweathermap.org/data/2.5/weather?q={input_str}&APPID={x}&units=metric"
     try:
         response_api = await async_searcher(sample_url, re_json=True)
-        if response_api["cod"] == 200:
+        if str(response_api.get("cod")) == "200":
             country_time_zone = int(response_api["timezone"])
             tz = f"{await get_timezone(country_time_zone)}"
             sun_rise_time = int(response_api["sys"]["sunrise"]) + country_time_zone
@@ -156,11 +158,11 @@ async def weather(event):
                 f"╰────────────────•\n\n"
             )
         else:
-            await msg.edit(response_api["message"])
-    except Exception as e:
+            await msg.edit(response_api.get("message", "Location not found. Try city,country format."))
+    except Exception:
         LOGS.exception("Weather lookup failed for input: %s", input_str)
         await event.eor(
-            f"Unable to fetch weather right now ({str(e)}). Try city,country format.",
+            "Unable to fetch weather right now. Try city,country format.",
             time=5,
         )
 
@@ -191,17 +193,21 @@ async def air_pollution(event):
     if air_error:
         await event.eor(air_error, time=5)
         return
-    await msg.edit(
-        f"{geocode_data['city']}, {geocode_data['prov']}\n\n"
-        f"╭────────────────•\n"
-        f"╰➢ **𝖠𝖰𝖨:** {air_pollution_data['main']['aqi']}\n"
-        f"╰➢ **𝖢𝖺𝗋𝖻𝗈𝗇 𝖬𝗈𝗇𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['co']}µg/m³\n"
-        f"╰➢ **𝖭𝗂𝗍𝗋𝗈𝗀𝖾𝗇 𝖬𝗈𝗇𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['no']}µg/m³\n"
-        f"╰➢ **𝖭𝗂𝗍𝗋𝗈𝗀𝖾𝗇 𝖣𝗂𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['no2']}µg/m³\n"
-        f"╰➢ **𝖮𝗓𝗈𝗇𝖾:** {air_pollution_data['components']['o3']}µg/m³\n"
-        f"╰➢ **𝖲𝗎𝗅𝗉𝗁𝗎𝗋 𝖣𝗂𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['so2']}µg/m³\n"
-        f"╰➢ **𝖠𝗆𝗆𝗈𝗇𝗂𝖺:** {air_pollution_data['components']['nh3']}µg/m³\n"
-        f"╰➢ **𝖥𝗂𝗇𝖾 𝖯𝖺𝗋𝗍𝗂𝖼𝗅𝖾𝗌 (PM₂.₅):** {air_pollution_data['components']['pm2_5']}\n"
-        f"╰➢ **𝖢𝗈𝖺𝗋𝗌𝖾 𝖯𝖺𝗋𝗍𝗂𝖼𝗅𝖾𝗌 (PM₁₀):** {air_pollution_data['components']['pm10']}\n"
-        f"╰────────────────•\n\n"
-    )
+    try:
+        await msg.edit(
+            f"{geocode_data['city']}, {geocode_data['prov']}\n\n"
+            f"╭────────────────•\n"
+            f"╰➢ **𝖠𝖰𝖨:** {air_pollution_data['main']['aqi']}\n"
+            f"╰➢ **𝖢𝖺𝗋𝖻𝗈𝗇 𝖬𝗈𝗇𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['co']}µg/m³\n"
+            f"╰➢ **𝖭𝗂𝗍𝗋𝗈𝗀𝖾𝗇 𝖬𝗈𝗇𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['no']}µg/m³\n"
+            f"╰➢ **𝖭𝗂𝗍𝗋𝗈𝗀𝖾𝗇 𝖣𝗂𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['no2']}µg/m³\n"
+            f"╰➢ **𝖮𝗓𝗈𝗇𝖾:** {air_pollution_data['components']['o3']}µg/m³\n"
+            f"╰➢ **𝖲𝗎𝗅𝗉𝗁𝗎𝗋 𝖣𝗂𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['so2']}µg/m³\n"
+            f"╰➢ **𝖠𝗆𝗆𝗈𝗇𝗂𝖺:** {air_pollution_data['components']['nh3']}µg/m³\n"
+            f"╰➢ **𝖥𝗂𝗇𝖾 𝖯𝖺𝗋𝗍𝗂𝖼𝗅𝖾𝗌 (PM₂.₅):** {air_pollution_data['components']['pm2_5']}\n"
+            f"╰➢ **𝖢𝗈𝖺𝗋𝗌𝖾 𝖯𝖺𝗋𝗍𝗂𝖼𝗅𝖾𝗌 (PM₁₀):** {air_pollution_data['components']['pm10']}\n"
+            f"╰────────────────•\n\n"
+        )
+    except (KeyError, TypeError):
+        LOGS.exception("Air pollution data missing display fields: %s", air_pollution_data)
+        await event.eor("Air quality data is incomplete for this location. Try city,country format.", time=5)

--- a/plugins/weather.py
+++ b/plugins/weather.py
@@ -19,11 +19,12 @@
 import datetime
 import time
 from datetime import timedelta
+from json import JSONDecodeError
 
 import aiohttp
 import pytz
 
-from . import async_searcher, get_string, udB, ultroid_cmd
+from . import LOGS, async_searcher, get_string, udB, ultroid_cmd
 
 
 async def get_timezone(offset_seconds, use_utc=False):
@@ -58,15 +59,56 @@ async def getWindinfo(speed: str, degree: str) -> str:
     return f"[{dirs[ix % len(dirs)]}] {kmph}"
 
 async def get_air_pollution_data(latitude, longitude, api_key):
-    url = f"http://api.openweathermap.org/data/2.5/air_pollution?lat={latitude}&lon={longitude}&appid={api_key}"
-    async with aiohttp.ClientSession() as session:
-        async with session.get(url) as response:
-            data = await response.json()
-            if "list" in data:
-                air_pollution = data["list"][0]
-                return air_pollution
-            else:
-                return None
+    url = f"https://api.openweathermap.org/data/2.5/air_pollution?lat={latitude}&lon={longitude}&appid={api_key}"
+    timeout = aiohttp.ClientTimeout(total=12)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url) as response:
+                data = await response.json()
+    except TimeoutError:
+        LOGS.exception("OpenWeather air pollution request timed out.")
+        return None, "Air quality lookup timed out. Please try again in a moment."
+    except aiohttp.ClientError:
+        LOGS.exception("OpenWeather air pollution request failed.")
+        return None, "Unable to reach the air quality service right now. Try again soon."
+    except (aiohttp.ContentTypeError, JSONDecodeError, ValueError):
+        LOGS.exception("Invalid air pollution response payload.")
+        return None, "Air quality service returned invalid data. Please try again."
+
+    try:
+        air_pollution = data["list"][0]
+    except (KeyError, IndexError, TypeError):
+        LOGS.exception("Air pollution response missing expected fields: %s", data)
+        return None, "No air quality data found for that location. Try city,country format."
+    return air_pollution, None
+
+
+async def get_geocode_data(input_str: str):
+    if input_str.lower() == "perth":
+        geo_url = "https://geocode.xyz/perth%20au?json=1"
+    else:
+        geo_url = f"https://geocode.xyz/{input_str}?json=1"
+    try:
+        geo_data = await async_searcher(geo_url, re_json=True, timeout=12)
+    except TimeoutError:
+        LOGS.exception("Geocoding request timed out for location: %s", input_str)
+        return None, "Geocoding timed out. Try city,country format."
+    except aiohttp.ClientError:
+        LOGS.exception("Geocoding request failed for location: %s", input_str)
+        return None, "Unable to reach geocoding service. Try again soon."
+    except (aiohttp.ContentTypeError, JSONDecodeError, ValueError, TypeError):
+        LOGS.exception("Geocoding response is not valid JSON for location: %s", input_str)
+        return None, "Could not read geocoding response. Try city,country format."
+
+    try:
+        latitude = geo_data["latt"]
+        longitude = geo_data["longt"]
+        city = geo_data["standard"]["city"]
+        prov = geo_data["standard"]["prov"]
+    except (KeyError, TypeError):
+        LOGS.exception("Geocoding response missing expected fields: %s", geo_data)
+        return None, "Location not found. Try city,country format (example: London,GB)."
+    return {"latitude": latitude, "longitude": longitude, "city": city, "prov": prov}, None
 
 
 @ultroid_cmd(pattern="weather ?(.*)")
@@ -83,10 +125,10 @@ async def weather(event):
         return
     input_str = event.pattern_match.group(1)
     if not input_str:
-        await event.eor("No Location was Given...", time=5)
+        await event.eor("No location was given. Try city,country format.", time=5)
         return
     elif input_str == "butler":
-        await event.eor("search butler,au for australila", time=5)
+        await event.eor("Search butler,au for Australia.", time=5)
     sample_url = f"https://api.openweathermap.org/data/2.5/weather?q={input_str}&APPID={x}&units=metric"
     try:
         response_api = await async_searcher(sample_url, re_json=True)
@@ -116,7 +158,11 @@ async def weather(event):
         else:
             await msg.edit(response_api["message"])
     except Exception as e:
-        await event.eor(f"An unexpected error occurred: {str(e)}", time=5)
+        LOGS.exception("Weather lookup failed for input: %s", input_str)
+        await event.eor(
+            f"Unable to fetch weather right now ({str(e)}). Try city,country format.",
+            time=5,
+        )
 
 
 @ultroid_cmd(pattern="air ?(.*)")
@@ -133,39 +179,24 @@ async def air_pollution(event):
         return
     input_str = event.pattern_match.group(1)
     if not input_str:
-        await event.eor("`No Location was Given...`", time=5)
+        await event.eor("No location was given. Try city,country format.", time=5)
         return
-    if input_str.lower() == "perth":
-        geo_url = f"https://geocode.xyz/perth%20au?json=1"
-    else:
-        geo_url = f"https://geocode.xyz/{input_str}?json=1"
-    geo_data = await async_searcher(geo_url, re_json=True)
-    try:
-        longitude = geo_data["longt"]
-        latitude = geo_data["latt"]
-    except KeyError as e:
-        LOGS.info(e)
-        await event.eor("`Unable to find coordinates for the given location.`", time=5)
+    geocode_data, geocode_error = await get_geocode_data(input_str)
+    if geocode_error:
+        await event.eor(geocode_error, time=5)
         return
-    try:
-        city = geo_data["standard"]["city"]
-        prov = geo_data["standard"]["prov"]
-    except KeyError as e:
-        LOGS.info(e)
-        await event.eor("`Unable to find city for the given coordinates.`", time=5)
-        return
-    air_pollution_data = await get_air_pollution_data(latitude, longitude, x)
-    if air_pollution_data is None:
-        await event.eor(
-            "`Unable to fetch air pollution data for the given location.`", time=5
-        )
+    air_pollution_data, air_error = await get_air_pollution_data(
+        geocode_data["latitude"], geocode_data["longitude"], x
+    )
+    if air_error:
+        await event.eor(air_error, time=5)
         return
     await msg.edit(
-        f"{city}, {prov}\n\n"
+        f"{geocode_data['city']}, {geocode_data['prov']}\n\n"
         f"╭────────────────•\n"
         f"╰➢ **𝖠𝖰𝖨:** {air_pollution_data['main']['aqi']}\n"
         f"╰➢ **𝖢𝖺𝗋𝖻𝗈𝗇 𝖬𝗈𝗇𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['co']}µg/m³\n"
-        f"╰➢ **𝖭𝗈𝗂𝗍𝗋𝗈𝗀𝖾𝗇 𝖬𝗈𝗇𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['no']}µg/m³\n"
+        f"╰➢ **𝖭𝗂𝗍𝗋𝗈𝗀𝖾𝗇 𝖬𝗈𝗇𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['no']}µg/m³\n"
         f"╰➢ **𝖭𝗂𝗍𝗋𝗈𝗀𝖾𝗇 𝖣𝗂𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['no2']}µg/m³\n"
         f"╰➢ **𝖮𝗓𝗈𝗇𝖾:** {air_pollution_data['components']['o3']}µg/m³\n"
         f"╰➢ **𝖲𝗎𝗅𝗉𝗁𝗎𝗋 𝖣𝗂𝗈𝗑𝗂𝖽𝖾:** {air_pollution_data['components']['so2']}µg/m³\n"

--- a/pyUltroid/version.py
+++ b/pyUltroid/version.py
@@ -1,2 +1,2 @@
 __version__ = "2026.04.05"
-ultroid_version = "2.1.4"
+ultroid_version = "2.1.5"

--- a/pyUltroid/version.py
+++ b/pyUltroid/version.py
@@ -1,2 +1,2 @@
-__version__ = "2026.04.03"
-ultroid_version = "2.1.2"
+__version__ = "2026.04.05"
+ultroid_version = "2.1.3"

--- a/pyUltroid/version.py
+++ b/pyUltroid/version.py
@@ -1,2 +1,2 @@
 __version__ = "2026.04.05"
-ultroid_version = "2.1.3"
+ultroid_version = "2.1.4"

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,0 @@
-# Lessons Learned
-
-- When users ask for follow-up fixes after a review, expand verification beyond syntax checks (e.g., run unit test suites and targeted plugin tests) before finalizing.
-- Avoid exposing raw exception text in user-facing bot responses; keep details in logs and return concise actionable guidance.
-- For location-hint branches (like `butler`), return immediately after sending the hint to avoid accidental follow-up API calls.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,5 @@
+# Lessons Learned
+
+- When users ask for follow-up fixes after a review, expand verification beyond syntax checks (e.g., run unit test suites and targeted plugin tests) before finalizing.
+- Avoid exposing raw exception text in user-facing bot responses; keep details in logs and return concise actionable guidance.
+- For location-hint branches (like `butler`), return immediately after sending the hint to avoid accidental follow-up API calls.


### PR DESCRIPTION
### Motivation
- Ensure the OpenWeather air pollution call uses a secure HTTPS endpoint and make geocoding and pollution lookups more resilient to network/timeouts/bad payloads. 
- Provide concise, actionable user-facing messages while preserving developer-visible logs for debugging. 
- Fix visible typos and make response style consistent between the `weather` and `air` commands. 
- Address a runtime bug where `LOGS` was used but not imported and update package version metadata.

### Description
- Switched the air pollution endpoint to `https://api.openweathermap.org/data/2.5/air_pollution` and added a client timeout to the request in `get_air_pollution_data`. 
- Reworked `get_air_pollution_data` to catch timeouts, `aiohttp.ClientError`, malformed JSON and missing fields, to log details via `LOGS.exception(...)` and return concise user-facing error messages (function now returns `(data, error)`). 
- Added a `get_geocode_data` helper that calls `geocode.xyz` via `async_searcher` with defensive handling of timeouts, client errors, invalid JSON and missing keys, returning a structured dict or a short user error. 
- Standardized no-input and failure messages between `weather` and `air`, fixed typos such as the Butler/Australia hint and the Nitrogen Monoxide label, and removed inconsistent backticks in user-facing text. 
- Imported `LOGS` into `plugins/weather.py` to fix the missing-log bug and bumped `pyUltroid/version.py` to `__version__ = "2026.04.05"` and `ultroid_version = "2.1.3"`.

### Testing
- Ran `python -m compileall plugins/weather.py pyUltroid/version.py` and the files compiled successfully. 
- Identified and fixed a runtime bug (missing `LOGS` import) during the changes, and verified the updated modules compile without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2551aa64083268aafac6361ff41be)